### PR TITLE
feat: 添加BFS剪枝，以及精简中转色到目标色的判断逻辑

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -32,3 +32,8 @@ export enum GameMode {
     CREATE = 'create',
     SOLUTION = 'solution',
 }
+
+export interface ColorCount {
+    count: number;
+    hasTargetColor: boolean;
+}

--- a/src/lib/utils/gridUtils.ts
+++ b/src/lib/utils/gridUtils.ts
@@ -174,3 +174,14 @@ export function getDescriptionObjectForSolutionStep(step: Step, index: number) {
         positionCol: step.position[1] + 1,
     }
 }
+
+export function getFirstClickableCell(matrix: number[][]): [number, number] | null {
+    for (let r = 0; r < matrix.length; r++) {
+        for (let c = 0; c < matrix[r].length; c++) {
+            if (matrix[r][c] !== LOCKED_CELL_VALUE) {
+                return [r, c];
+            }
+        }
+    }
+    return null;
+}

--- a/src/lib/utils/gridUtils.ts
+++ b/src/lib/utils/gridUtils.ts
@@ -1,5 +1,5 @@
 /* File: src/lib/utils/gridUtils.ts */
-import type {Step} from "$lib/types";
+import type {ColorCount, Step} from "$lib/types";
 
 export const LOCKED_CELL_VALUE = -1;
 
@@ -21,6 +21,24 @@ export function isGoalState(matrix: number[][], targetColor: number): boolean {
 
 export function isAllTargetColor(matrix: number[][], targetColor: number): boolean {
     return isGoalState(matrix, targetColor);
+}
+
+export function getColorCount(matrix: number[][], targetColor: number): ColorCount {
+    const colorCount: ColorCount = { count: 0, hasTargetColor: false };
+    const colorSet = new Set<number>();
+    for (const row of matrix) {
+        for (const cell of row) {
+            if (cell === LOCKED_CELL_VALUE) {
+                continue;
+            }
+            colorSet.add(cell);
+            if (cell === targetColor) {
+                colorCount.hasTargetColor = true;
+            }
+        }
+    }
+    colorCount.count = colorSet.size;
+    return colorCount;
 }
 
 

--- a/src/lib/utils/solver.ts
+++ b/src/lib/utils/solver.ts
@@ -1,6 +1,6 @@
 /* File: src/lib/utils/solver.ts */
 
-import {cloneMatrix, matrixToString, isAllTargetColor, LOCKED_CELL_VALUE, getCodeOfTrueColors} from './gridUtils';
+import {cloneMatrix, matrixToString, isAllTargetColor, LOCKED_CELL_VALUE, getCodeOfTrueColors, getColorCount} from './gridUtils';
 import type { Step, BFSResult } from "$lib/types";
 
 /**
@@ -232,12 +232,18 @@ export function aStarSolve(
         const { matrix, g, h, steps } = current;
 
         // 检查是否已达全目标色
-        if (isAllTargetColor(matrix, targetColor)) {
+        const colorCount = getColorCount(matrix, targetColor);
+        if (colorCount.count === 1 && colorCount.hasTargetColor) {
             return { type: 'success', steps };
         }
 
         // 若已走到 maxSteps，就不再深入
         if (g >= maxSteps) {
+            continue;
+        }
+
+        // 如果剩余步数不足以合并所有颜色，则剪枝
+        if (g + (colorCount.count - (colorCount.hasTargetColor ? 1 : 0)) > maxSteps) {
             continue;
         }
 

--- a/src/lib/utils/solverWorker.ts
+++ b/src/lib/utils/solverWorker.ts
@@ -1,5 +1,5 @@
 /* File: src/lib/utils/solverWorker.ts */
-import { solvePuzzleWithFallback } from './solver';
+import { aStarSolve } from './solver';
 import type { BFSResult } from '$lib/types';
 
 self.addEventListener('message', async (e) => {
@@ -11,7 +11,7 @@ self.addEventListener('message', async (e) => {
 
     let result: BFSResult;
     try {
-        result = solvePuzzleWithFallback(grid, targetColor, maxSteps);
+        result = aStarSolve(grid, targetColor, maxSteps);
     } catch (err) {
         result = {
             type: 'failure',

--- a/src/tests/puzzleTests.spec.ts
+++ b/src/tests/puzzleTests.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { describe, it, expect } from 'vitest';
-import { solvePuzzleWithFallback } from '$lib/utils/solver';
+import { aStarSolve } from '$lib/utils/solver';
 
 // 递归或手动拼接 static/puzzles_json 路径
 // 注意 __dirname 在 ESM 环境下可能不可用，可改用 import.meta.url 处理
@@ -29,7 +29,7 @@ describe('Test all puzzles in static/puzzles_json (exclude list.json)', () => {
             const stepsLimit = parseInt(maxSteps, 10) || 10;
 
             // 调用 A* 求解
-            const result = solvePuzzleWithFallback(grid, targetColor, stepsLimit);
+            const result = aStarSolve(grid, targetColor, stepsLimit);
 
             // 如果想要断言它一定成功，就检查
             expect(result.type).toBe('success');


### PR DESCRIPTION
有个剪枝条件可以直接优化BFS时间复杂度中的指数部分（和最大步数相关）：
不难注意到，理想状态下，一次点击操作会把场上的颜色A全部转换成颜色B（在场上的颜色A格子全部连在一个分区内时）。因此，不难得出以下结论：

- 当矩阵中没有目标色格子时，剩余N种颜色的情况下最少需要N步才能把矩阵全部染成目标色
- 当矩阵中有目标色格子时，剩余N种颜色的情况下最少需要N-1步才能把矩阵全部染成目标色

因此，我们可以提前进行判断，剩余步数不满足上述规则时直接剪枝，以减少无效搜索。

以及可以直接在Astar流程中判断中转色加一步能否变成目标色（当场上只有一种颜色且还有剩余步数的情况下），精简了代码，也避免了重复跑Astar算法的消耗。

其实这些优化手段一开始都是我用来优化DFS算法的，硬生生把DFS优化到所有官方关卡都能在10秒内解出答案。后面测了下，加上上述两个优化手段的Astar直接能在1秒内跑出答案，属实是拼尽全力无法战胜了。
